### PR TITLE
Fix progress completion

### DIFF
--- a/csv-splitter.py
+++ b/csv-splitter.py
@@ -160,6 +160,12 @@ class CSVSplitter(QWidget):
                     new_name = os.path.join(output_dir, f"{name}_{i}_of_{written_files}{ext}")
                     os.rename(old_name, new_name)
 
+                # When no header is included the final loop may leave the
+                # progress bar one step shy of the maximum.  Explicitly set the
+                # value to ensure it reaches 100%.
+                if self.progress_bar.value() < self.progress_bar.maximum():
+                    self.progress_bar.setValue(self.progress_bar.maximum())
+
                 QMessageBox.information(self, "Success", f"File successfully split into {written_files} parts.")
 
         finally:


### PR DESCRIPTION
## Summary
- ensure progress bar is forced to 100% at the end of splitting

## Testing
- `python -m py_compile csv-splitter.py number_input.py`

------
https://chatgpt.com/codex/tasks/task_e_686558df19b88322b4cc49dce7a26cfe