### PR TITLE
Include icons in PyInstaller build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,12 @@ jobs:
 
       - name: Build executable
         run: |
-          pyinstaller csv-splitter.py --clean --noupx --noconsole --noconfirm --onefile --windowed
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            ADD_DATA="app_icon.ico;."
+          else
+            ADD_DATA="app_icon.ico:."
+          fi
+          pyinstaller csv-splitter.py --clean --noupx --noconsole --noconfirm --onefile --windowed --icon=app_icon.ico --add-data "$ADD_DATA"
 
       - name: Rename artifact
         run: |


### PR DESCRIPTION
## Summary
- bundle the app icon when building executables
- pass `--icon` and `--add-data` options so the icon ships across OSes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686558eb97a08322a80d148dad22444c