### PR TITLE
Add pytest workflow and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build CSV Splitter
 on:
   push:
     branches: [main]
+  pull_request:
   release:
     types: [created]
 
@@ -28,6 +29,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pyinstaller
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -q
 
       - name: Build executable
         run: |

--- a/split_logic.py
+++ b/split_logic.py
@@ -1,0 +1,63 @@
+import os
+from typing import List
+
+
+def split_csv_file(file_path: str, lines_per_file: int, include_header: bool = True) -> List[str]:
+    """Split a text-based file into multiple smaller files.
+
+    Parameters
+    ----------
+    file_path: str
+        Path to the input CSV (or text) file.
+    lines_per_file: int
+        Maximum number of lines (excluding header) in each split file.
+    include_header: bool, default True
+        Whether to include the first line of the source file at the top of each
+        split file.
+
+    Returns
+    -------
+    List[str]
+        Paths to the generated files.
+    """
+    base_name = os.path.basename(file_path)
+    name, ext = os.path.splitext(base_name)
+    output_dir = os.path.dirname(file_path)
+
+    with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+        header = f.readline() if include_header else ""
+        lines = []
+        file_index = 1
+        written_files = 0
+        output_paths: List[str] = []
+
+        for line in f:
+            lines.append(line)
+            if len(lines) >= lines_per_file:
+                written_files += 1
+                output_path = os.path.join(output_dir, f"{name}_{file_index}_of_XXX{ext}")
+                with open(output_path, "w", encoding="utf-8") as out_file:
+                    if include_header:
+                        out_file.write(header)
+                    out_file.writelines(lines)
+                output_paths.append(output_path)
+                lines = []
+                file_index += 1
+
+        if lines:
+            written_files += 1
+            output_path = os.path.join(output_dir, f"{name}_{file_index}_of_XXX{ext}")
+            with open(output_path, "w", encoding="utf-8") as out_file:
+                if include_header:
+                    out_file.write(header)
+                out_file.writelines(lines)
+            output_paths.append(output_path)
+
+    for i in range(1, written_files + 1):
+        old_name = os.path.join(output_dir, f"{name}_{i}_of_XXX{ext}")
+        new_name = os.path.join(output_dir, f"{name}_{i}_of_{written_files}{ext}")
+        os.rename(old_name, new_name)
+        output_paths[i - 1] = new_name
+
+    return output_paths
+

--- a/tests/test_split_logic.py
+++ b/tests/test_split_logic.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from split_logic import split_csv_file
+
+
+def test_split_csv_file(tmp_path):
+    # Create a temporary CSV file with a header and five lines
+    input_file = tmp_path / "sample.csv"
+    content = "header1,header2\n" + "\n".join(f"val{i},val{i}" for i in range(5)) + "\n"
+    input_file.write_text(content)
+
+    # Split into files with at most 2 lines per part (excluding header)
+    output_files = split_csv_file(str(input_file), lines_per_file=2, include_header=True)
+
+    assert len(output_files) == 3
+
+    expected_names = [
+        tmp_path / "sample_1_of_3.csv",
+        tmp_path / "sample_2_of_3.csv",
+        tmp_path / "sample_3_of_3.csv",
+    ]
+    assert [os.path.abspath(p) for p in output_files] == [str(p) for p in expected_names]
+
+    # Verify contents of each part
+    parts = [p.read_text().splitlines() for p in expected_names]
+
+    assert parts[0] == ["header1,header2", "val0,val0", "val1,val1"]
+    assert parts[1] == ["header1,header2", "val2,val2", "val3,val3"]
+    assert parts[2] == ["header1,header2", "val4,val4"]


### PR DESCRIPTION
## Summary
- add an extraction of the splitting logic (`split_csv_file`)
- add pytest test for split_csv_file
- run tests in CI
- trigger workflow on pull requests
- verify all output file contents in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686559023ae483229900c58cf8213c87