### PR TITLE
Include icons in PyInstaller build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,17 @@ jobs:
 
       - name: Build executable
         run: |
-          pyinstaller csv-splitter.py --clean --noupx --noconsole --noconfirm --onefile --windowed
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            ADD_DATA="app_icon.ico;."
+            ICON="app_icon.ico"
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            ADD_DATA="app_icon.icns:."
+            ICON="app_icon.icns"
+          else
+            ADD_DATA="app_icon.ico:."
+            ICON="app_icon.ico"
+          fi
+          pyinstaller csv-splitter.py --clean --noupx --noconsole --noconfirm --onefile --windowed --icon="$ICON" --add-data "$ADD_DATA"
 
       - name: Rename artifact
         run: |


### PR DESCRIPTION
## Summary
- bundle the app icon when building executables
- choose a platform-specific icon file so macOS uses `.icns`

## Testing
- `python -m py_compile csv-splitter.py number_input.py`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686558eb97a08322a80d148dad22444c